### PR TITLE
Change networks object to enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as networks } from "./networks";
+export { networks } from "./networks";
 export * from "./legos";

--- a/src/modules/compound/contracts.ts
+++ b/src/modules/compound/contracts.ts
@@ -3,7 +3,7 @@ import CompoundPriceOracleAbi from "./abi/CompoundPriceOracle.json";
 import CTokenAbi from "./abi/CToken.json";
 import CEtherAbi from "./abi/CEther.json";
 
-import networks from "../../networks";
+import { networks } from "../../networks";
 
 const contracts = {
   cTokenAbi: CTokenAbi,

--- a/src/modules/erc20/contracts.ts
+++ b/src/modules/erc20/contracts.ts
@@ -1,42 +1,42 @@
 import ERC20Abi from "./abi/ERC20.json";
 
-import networkIds from "../../networks";
+import {networks} from "../../networks";
 
 const contracts = {
   abi: ERC20Abi,
   bat: {
     address: {
-      [networkIds.mainnet]: "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+      [networks.mainnet]: "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
     },
   },
   dai: {
     address: {
-      [networkIds.mainnet]: "0x6b175474e89094c44da98b954eedeac495271d0f",
+      [networks.mainnet]: "0x6b175474e89094c44da98b954eedeac495271d0f",
     },
   },
   rep: {
     address: {
-      [networkIds.mainnet]: "0x1985365e9f78359a9B6AD760e32412f4a445E862",
+      [networks.mainnet]: "0x1985365e9f78359a9B6AD760e32412f4a445E862",
     },
   },
   sai: {
     address: {
-      [networkIds.mainnet]: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      [networks.mainnet]: "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
     },
   },
   usdc: {
     address: {
-      [networkIds.mainnet]: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      [networks.mainnet]: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     },
   },
   wbtc: {
     address: {
-      [networkIds.mainnet]: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+      [networks.mainnet]: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
     },
   },
   zrx: {
     address: {
-      [networkIds.mainnet]: "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+      [networks.mainnet]: "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
     },
   },
 };

--- a/src/modules/maker/contracts.ts
+++ b/src/modules/maker/contracts.ts
@@ -2,7 +2,7 @@ import makerProxyRegistryAbi from "./abi/ProxyRegistry.json";
 import dssCdpManagerAbi from "./abi/DssCdpManager.json";
 import dssProxyActionsAbi from "./abi/DssProxyActions.json";
 
-import networks from "../../networks";
+import { networks } from "../../networks";
 
 const contracts = {
   proxyRegistry: {

--- a/src/modules/maker/ilks.ts
+++ b/src/modules/maker/ilks.ts
@@ -1,5 +1,5 @@
 import erc20 from "../erc20";
-import networks from "../../networks";
+import { networks } from "../../networks";
 
 const ilks = {
   batA: {

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,9 +1,7 @@
-const networks = {
-  mainnet: 1,
-  ropsten: 3,
-  rinkeby: 4,
-  goerli: 5,
-  kovan: 42,
-};
-
-export default networks;
+export enum networks {
+  mainnet = 1,
+  ropsten = 3,
+  rinkeby = 4,
+  goerli = 5,
+  kovan = 42,
+}


### PR DESCRIPTION
According to Bergi's SO suggestion [here](https://stackoverflow.com/questions/61148942/how-to-provide-structural-information-on-dynamically-generated-json?noredirect=1#comment108178783_61148942), I should be able to change the `networks` object into an enum and it should show auto-complete information.

However, I made the change and encountered the following error on Typescript compilation (i.e. `tsc`):

```
src/legos.ts:5:14 - error TS4023: Exported variable 'rawLegos' has or is using name 'networks' from external module "/Users/adrianli/dev/money-legos/src/modules/compound/contracts" but cannot be named.

5 export const rawLegos = {
               ~~~~~~~~

src/legos.ts:5:14 - error TS4023: Exported variable 'rawLegos' has or is using name 'networks' from external module "/Users/adrianli/dev/money-legos/src/modules/erc20/contracts" but cannot be named.

5 export const rawLegos = {
               ~~~~~~~~

src/legos.ts:5:14 - error TS4023: Exported variable 'rawLegos' has or is using name 'networks' from external module "/Users/adrianli/dev/money-legos/src/modules/maker/contracts" but cannot be named.

5 export const rawLegos = {
               ~~~~~~~~

src/legos.ts:5:14 - error TS4023: Exported variable 'rawLegos' has or is using name 'networks' from external module "/Users/adrianli/dev/money-legos/src/modules/maker/ilks" but cannot be named.

5 export const rawLegos = {
               ~~~~~~~~

src/modules/compound/index.ts:4:1 - error TS4082: Default export of the module has or is using private name 'networks'.

4 export default {
  ~~~~~~~~~~~~~~~~
5   cTokenAbi: CTokenAbi,
  ~~~~~~~~~~~~~~~~~~~~~~~
6   contracts,
  ~~~~~~~~~~~~
7 };
  ~~

src/modules/erc20/index.ts:3:1 - error TS4082: Default export of the module has or is using private name 'networks'.

3 export default {
  ~~~~~~~~~~~~~~~~
4   contracts,
  ~~~~~~~~~~~~
5 };
  ~~

src/modules/maker/ilks.ts:4:7 - error TS4023: Exported variable 'ilks' has or is using name 'networks' from external module "/Users/adrianli/dev/money-legos/src/modules/erc20/contracts" but cannot be named.

4 const ilks = {
        ~~~~

src/modules/maker/index.ts:4:1 - error TS4082: Default export of the module has or is using private name 'networks'.

4 export default {
  ~~~~~~~~~~~~~~~~
5   contracts,
  ~~~~~~~~~~~~
6   ilks,
  ~~~~~~~
7 };
  ~~


Found 8 errors.

error Command failed with exit code 1.
```